### PR TITLE
fix(ios): avatar tap opens bio; pad hover-preview gated to (hover: hover)

### DIFF
--- a/e2e/avatar-close.test.ts
+++ b/e2e/avatar-close.test.ts
@@ -7,7 +7,25 @@ import { test, expect } from '@playwright/test';
  * mouseenter/focus handlers. After the fix, the close button
  * actually closes the panel and the bio stays closed even with the
  * cursor still over the avatar.
+ *
+ * Follow-up iOS bug (post-#47): on touch a tap fires onclick but
+ * neither onmouseenter nor onfocus fired reliably on the avatar
+ * button, so the bio panel never opened on iPhone/iPad. The fix
+ * routes onclick through maybeOpen so a tap opens the panel.
  */
+test.describe('Avatar — tap on touch opens the bio panel (iOS regression)', () => {
+  test.use({ hasTouch: true });
+
+  test('tap opens the panel even without hover/focus events', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('.avatar', { timeout: 5000 });
+    const avatar = page.locator('.avatar');
+    await expect(avatar).not.toHaveClass(/open/);
+    await avatar.tap();
+    await expect(avatar).toHaveClass(/open/);
+  });
+});
+
 test.describe('Avatar — "–" closes and stays closed (#47)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');

--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -116,7 +116,20 @@
   onmouseleave={handleLeave}
   onfocus={maybeOpen}
   onblur={handleBlur}
-  onclick={onExpand}
+  onclick={() => {
+    /* On touch (iOS Safari + Chrome on iOS) neither onmouseenter nor
+     * onfocus fires reliably for a tap on a <button> — synthesized
+     * mouseenter is iffy across versions and Safari doesn't focus
+     * non-form buttons on tap by default. Without a click handler that
+     * opens the panel, tapping the avatar did nothing visible. Route
+     * onclick through the same maybeOpen guard the other openers use
+     * (suppressReopen short-circuits it so the close button's unmount
+     * cascade still can't reopen the panel), then forward to the
+     * optional onExpand callback so the future full-overlay hook
+     * keeps working when wired up. */
+    maybeOpen();
+    onExpand?.();
+  }}
 >
   <span class="avatar-shell" aria-hidden="true">
     <span class="avatar-photo-wrap">

--- a/src/components/Knob.svelte
+++ b/src/components/Knob.svelte
@@ -541,17 +541,28 @@
      state. A subtle drop-shadow filter also lifts the hovered pad
      off the dial to reinforce press affordance (filter works on SVG
      paths where CSS transform translateY can be flaky). */
-  .knob:has(.target-top:hover) .pad-green:not(.active) {
-    fill: oklch(0.84 0.15 138);
-    filter: drop-shadow(0 -2px 3px oklch(0.45 0.10 145 / 0.35));
-  }
-  .knob:has(.target-bl:hover) .pad-amber:not(.active) {
-    fill: oklch(0.90 0.14 90);
-    filter: drop-shadow(0 -2px 3px oklch(0.55 0.12 90 / 0.35));
-  }
-  .knob:has(.target-br:hover) .pad-neutral:not(.active) {
-    fill: oklch(0.66 0.028 70);
-    filter: drop-shadow(0 -2px 3px oklch(0.40 0.02 70 / 0.30));
+  /* Hover preview — "warming up" toward the active fill — is gated to
+     hover-capable, fine-pointer devices only. iOS Safari (and Chrome
+     on iOS, which is WebKit under the hood) treats a tap as a sticky
+     :hover that persists until something else is tapped, so without
+     this gate the moment a user tapped a pad to DEselect it the
+     :hover rule below clamped the fill back to the saturated preview
+     color and the transparent inactive state never appeared until they
+     also tapped the background. (hover: hover) AND (pointer: fine)
+     rules out the touch + coarse-pointer combination together. */
+  @media (hover: hover) and (pointer: fine) {
+    .knob:has(.target-top:hover) .pad-green:not(.active) {
+      fill: oklch(0.84 0.15 138);
+      filter: drop-shadow(0 -2px 3px oklch(0.45 0.10 145 / 0.35));
+    }
+    .knob:has(.target-bl:hover) .pad-amber:not(.active) {
+      fill: oklch(0.90 0.14 90);
+      filter: drop-shadow(0 -2px 3px oklch(0.55 0.12 90 / 0.35));
+    }
+    .knob:has(.target-br:hover) .pad-neutral:not(.active) {
+      fill: oklch(0.66 0.028 70);
+      filter: drop-shadow(0 -2px 3px oklch(0.40 0.02 70 / 0.30));
+    }
   }
 
   /* Pad labels — sized in SVG user units so text scales with the dial.

--- a/tests/knob-pad-states.test.ts
+++ b/tests/knob-pad-states.test.ts
@@ -30,6 +30,31 @@ function escapeForRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+describe('Knob pad hover-preview gating (iOS sticky-hover regression)', () => {
+  /* iOS Safari (and Chrome on iOS) treats a tap as a sticky :hover
+   * that persists until something else is tapped. Without a
+   * `(hover: hover) and (pointer: fine)` gate, the pad's hover-warming
+   * rule clamps the fill on the first tap so a subsequent
+   * deselection never reveals the transparent inactive state until
+   * the user also taps the background. This test guards the gate
+   * structurally — it lives in the source, so any future drop of the
+   * @media wrapper trips the assertion immediately. */
+  it('wraps every pad :hover rule in @media (hover: hover) and (pointer: fine)', () => {
+    const hoverGateRe = /@media\s*\(hover:\s*hover\)\s*and\s*\(pointer:\s*fine\)\s*\{[\s\S]*?\.knob:has\(\.target-(?:top|bl|br):hover\)[\s\S]*?\.knob:has\(\.target-(?:top|bl|br):hover\)[\s\S]*?\.knob:has\(\.target-(?:top|bl|br):hover\)[\s\S]*?\}/;
+    expect(KNOB_SVELTE).toMatch(hoverGateRe);
+  });
+
+  it('does NOT carry any ungated `.target-*:hover` selector that fills a pad', () => {
+    // Strip out everything inside `@media (hover: hover) ...` blocks
+    // first; any `.target-*:hover` selector left over would be a leak.
+    const withoutGated = KNOB_SVELTE.replace(
+      /@media\s*\(hover:\s*hover\)\s*and\s*\(pointer:\s*fine\)\s*\{[\s\S]*?\n  \}/g,
+      '',
+    );
+    expect(withoutGated).not.toMatch(/\.knob:has\(\.target-(?:top|bl|br):hover\)\s*\.pad-/);
+  });
+});
+
 describe('Knob pad fills (#46)', () => {
   it('inactive See-Work pad uses an alpha-bearing oklch fill', () => {
     const fill = extractFill('.pad-green');


### PR DESCRIPTION
## Summary

Two iOS Safari / Chrome-on-iOS bugs surfaced in the v0.1.0 smoke test on iPhone 14, after PR #55 landed. Same release wave — folding these into the apex cut before the v0.1.0 tag goes live.

### Bug 1: tapping the avatar never opened the bio panel

On touch, `onmouseenter` and `onfocus` don't fire reliably on a non-form `<button>` in WebKit (synthesized mouseenter is iffy across versions; Safari doesn't focus non-form buttons on tap by default). `onclick` *did* fire but was wired only to `onExpand`, which is a TODO in Dashboard, so a tap looked dead.

**Fix:** route `onclick` through the existing `maybeOpen` helper (which already carries the `suppressReopen` guard so the close-button unmount cascade can't reopen the panel), then forward to `onExpand` for the future full-overlay hook.

### Bug 2: pad hover-preview pinned on iOS after toggle-off

Tapping a See-Work or GTK pad to deselect it kept the saturated "warming up" preview fill instead of dropping to the new transparent inactive state from #46 — until the user also tapped somewhere else. WebKit's sticky `:hover` treats a tap as hover that persists until another element is tapped, so the hover-preview CSS rule clamped the pad fill on every deselect.

**Fix:** wrap the three pad hover-preview rules in `@media (hover: hover) and (pointer: fine)` so they only apply on devices with real hover semantics. The active and inactive fills are unchanged.

## Tests

- `e2e/avatar-close.test.ts` gains a touch-context describe block (`test.use({ hasTouch: true })`) that asserts a single `.avatar.tap()` flips it to `.open` with no hover or focus involved.
- `tests/knob-pad-states.test.ts` gains two structural assertions that every `.target-*:hover` pad rule lives inside the `@media (hover: hover) and (pointer: fine)` wrapper, and that no equivalent rule leaks out of the gate.

Unit suite: **101/101 passing locally** (was 99; +2). Build green.

## Test plan

- [ ] CI: Vitest + Playwright suites green (mobile project picks up the new touch test).
- [ ] Smoke on iPhone after merge: tap avatar → bio opens; toggle a pad off → fill goes transparent immediately, no second tap needed.

## Coordinated with v0.1.0

The local `v0.1.0` tag I prepared was annotated at `88f873e` (the previous merge). After this PR merges I'll re-point the local tag to the new HEAD and hand off the push command + updated release notes. Nothing else in the apex cutover changes.

https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh)_