### PR TITLE
fix(scrambler): cluster orbit gets stuck after card collapse (critical)

### DIFF
--- a/e2e/scrambler-tap-pause.test.ts
+++ b/e2e/scrambler-tap-pause.test.ts
@@ -122,3 +122,109 @@ test.describe('Scrambler — background tap pauses all clusters (#43)', () => {
     }
   });
 });
+
+/**
+ * Critical post-v0.1.0 regression: after a user collapsed a card via
+ * the – button, the cluster that owned that card stayed paused
+ * indefinitely. Sibling clusters resumed normally, and bg-tap
+ * unpause didn't unstick the affected cluster. Root cause:
+ * .scrambler-cluster is inset: 0 so the cluster fills the entire
+ * Scrambler; collapsing under-cursor never fires pointerleave, so
+ * hoverPaused stays true forever after anyCardOpen flips false.
+ */
+test.describe('Scrambler — cluster resumes after collapse with pointer parked', () => {
+  test('cluster orbit resumes after card collapses, pointer still over cluster', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.waitForSelector('.scrambler-card', { timeout: 5000 });
+
+    const firstCard = page.locator('.scrambler-card').first();
+    const cluster = page.locator('.scrambler-cluster').first();
+
+    // Mouse-hover the card so the cluster registers a mouse-pointer
+    // hoverPaused (touch never sets it; the bug is desktop-only).
+    await firstCard.hover();
+    await expect(cluster).toHaveClass(/paused/);
+
+    // Two pointerup taps to advance orbital → focused → expanded.
+    for (let i = 0; i < 2; i++) {
+      await firstCard.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
+        const down = new PointerEvent('pointerdown', {
+          bubbles: true,
+          pointerType: 'mouse',
+          clientX: cx,
+          clientY: cy,
+          pointerId: 1,
+        });
+        const up = new PointerEvent('pointerup', {
+          bubbles: true,
+          pointerType: 'mouse',
+          clientX: cx,
+          clientY: cy,
+          pointerId: 1,
+        });
+        el.dispatchEvent(down);
+        el.dispatchEvent(up);
+      });
+    }
+    await expect(firstCard).toHaveClass(/expanded/);
+
+    // Click the – toggle on the now-expanded card. The pointer ends
+    // up at the – button screen position — still inside the cluster's
+    // bounds — and the card shrinks under it. This is the exact
+    // gesture that produces the stuck-pause bug.
+    await page.locator('.scrambler-card.expanded .card-toggle').click();
+    await expect(firstCard).not.toHaveClass(/expanded/);
+    await expect(firstCard).not.toHaveClass(/focused/);
+
+    // Past the 800ms recentlyCollapsed grace + margin. The cluster
+    // must NOT carry .paused — that's the regression we're guarding.
+    await page.waitForTimeout(1200);
+    await expect(cluster).not.toHaveClass(/paused/);
+  });
+
+  test('cluster also resumes when card is dismissed via background tap', async ({
+    page,
+  }) => {
+    // Same shape but with the outside-tap close path (the bg-tap
+    // route from #43's A1 regression). Covers the second close
+    // pathway end-to-end.
+    await page.goto('/');
+    await page.waitForSelector('.scrambler-card', { timeout: 5000 });
+
+    const firstCard = page.locator('.scrambler-card').first();
+    const cluster = page.locator('.scrambler-cluster').first();
+
+    await firstCard.hover();
+    await expect(cluster).toHaveClass(/paused/);
+
+    for (let i = 0; i < 2; i++) {
+      await firstCard.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
+        el.dispatchEvent(new PointerEvent('pointerdown', {
+          bubbles: true, pointerType: 'mouse', clientX: cx, clientY: cy, pointerId: 1,
+        }));
+        el.dispatchEvent(new PointerEvent('pointerup', {
+          bubbles: true, pointerType: 'mouse', clientX: cx, clientY: cy, pointerId: 1,
+        }));
+      });
+    }
+    await expect(firstCard).toHaveClass(/expanded/);
+
+    // Bg-tap on cluster — closes the card via ScramblerCard's
+    // outside-tap effect.
+    await cluster.evaluate((el) => {
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await expect(firstCard).not.toHaveClass(/expanded/);
+
+    await page.waitForTimeout(1200);
+    await expect(cluster).not.toHaveClass(/paused/);
+  });
+});

--- a/src/components/ScramblerCluster.svelte
+++ b/src/components/ScramblerCluster.svelte
@@ -97,6 +97,31 @@
         recentlyCollapsed = false;
         collapseTimer = undefined;
       }, 800);
+      /* Critical: clear hoverPaused and focusPaused on collapse.
+       *
+       * .scrambler-cluster is `position: absolute; inset: 0`, so the
+       * cluster fills the entire Scrambler region. When an expanded
+       * card collapses while the user's pointer is on its `–` close
+       * button, the card shrinks back to its orbital size but the
+       * pointer remains inside the cluster's bounds — no pointerleave
+       * fires. hoverPaused stays true forever, locking that single
+       * cluster's orbit even after anyCardOpen flips false and the
+       * recentlyCollapsed grace expires. Sibling clusters resume
+       * normally because the pointer was never over them, so the
+       * symptom presents as "the cluster whose card I just closed
+       * is the only one stuck", and bg-tap unpause doesn't help
+       * because it toggles tapPaused, not hoverPaused.
+       *
+       * Clearing both flags here resets the local pause state to the
+       * just-collapsed baseline. If the user actually moves the
+       * pointer onto a cluster from outside afterward, pointerenter
+       * will re-engage hover-pause as usual; if they keep the pointer
+       * parked, the orbit resumes (which is the intended close-gesture
+       * UX). focusPaused is force-cleared as belt-and-braces alongside
+       * — the global pointerdown listener usually handles it, but a
+       * keyboard-driven close path (Esc) doesn't fire pointerdown. */
+      hoverPaused = false;
+      focusPaused = false;
     } else if (!prevAnyCardOpen && open) {
       if (collapseTimer !== undefined) {
         clearTimeout(collapseTimer);


### PR DESCRIPTION
## Summary

**Critical bug** reported on v0.1.0: collapsing a card left that card's cluster paused forever while sibling clusters resumed orbiting normally. Bg-tap pause/unpause did not unstick the affected cluster. Most often hit on GTK, sometimes also See Work — whichever cluster owned the last-closed card.

## Root cause

`.scrambler-cluster` is `position: absolute; inset: 0`, so each cluster fills the entire Scrambler region. When an expanded card collapses while the pointer is on the `–` close button, the card shrinks back to its orbital size but the pointer remains inside the cluster's bounds → **no `pointerleave` fires** → `hoverPaused` stays true.

Among the six pause reasons aggregated by `isOrbitPaused()`, `hoverPaused` is the only one with no implicit clear pathway:

| Reason | Clear pathway |
|---|---|
| `tap` (shared) | bg-tap toggle |
| `anyCardOpen` (shared) | MutationObserver on `.focused`/`.expanded` classes |
| `focusPaused` | `focusout` + global capture-phase `pointerdown` listener |
| `dragging` | drag-end / pointercancel |
| `recentlyCollapsed` | 800ms timer |
| **`hoverPaused`** | **`pointerleave` / `pointercancel` only** |

So a stuck `hoverPaused=true` survives bg-tap toggles, focus changes, drag-end, and grace expiry. Sibling clusters resumed correctly because the pointer was never over them during the open/close cycle, so their `hoverPaused` never got set in the first place — hence the asymmetric "the cluster whose card I just closed is the only one stuck" symptom.

## Fix

In the existing `prevAnyCardOpen` `$effect`, on the `true → false` transition, force-clear `hoverPaused` and `focusPaused` alongside arming the `recentlyCollapsed` grace timer. The 800ms grace continues to pause the orbit for the spring-settle window. After grace expires:

- If pointer is still parked inside the cluster, orbit resumes (closing a card is an explicit "I'm done reading" gesture).
- If pointer moves onto a cluster from outside, `pointerenter` re-engages hover-pause as usual.

`focusPaused` gets the same treatment as belt-and-braces — the global pointerdown listener usually clears it, but a keyboard-driven close (Esc) doesn't fire pointerdown.

## Tests

`e2e/scrambler-tap-pause.test.ts` gains a new describe block with two regression tests:

1. **Close via `–` button** — hover a card, advance through orbital → focused → expanded, click the `–` toggle, wait past the 800ms grace, assert the cluster does NOT carry `.paused`.
2. **Close via bg-tap** — same shape but uses the outside-tap close path. Covers both close pathways.

Both tests fail on baseline (`5063b30`, before this fix) and pass after the fix.

Unit suite: **101/101 passing locally**. Build green.

## Trade-off (filed in commit as comment)

A user who closes a card and immediately wants to re-engage hover-pause on the *same* cluster without moving the mouse will need to move the pointer off+back-on to re-trigger pointerenter. This is a mild regression for a rare path; the critical bug fix is more valuable.

## Coordinated with v0.1.1

v0.1.0 was already published; v0.1.1 was being decided (option A in the prior conversation). After this merges I'll re-prep the v0.1.1 release notes to include this fix alongside the iOS tap-handling fixes, ready for a single Release publication.

## Test plan

- [ ] CI: Workers Build green on PR
- [ ] Smoke on desktop: open card → click `–` → orbit resumes; bg-tap also closes and resumes
- [ ] Smoke on iPhone: tap card to focus, tap to expand, tap `–` → orbit resumes (touch never sets hoverPaused, so this case is regression-checked by the existing tests, not specifically by the new ones)

https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh)_