### PR TITLE
refactor(scrambler): unify pause state on the parent (all-or-nothing)

### DIFF
--- a/e2e/scrambler-tap-pause.test.ts
+++ b/e2e/scrambler-tap-pause.test.ts
@@ -124,13 +124,80 @@ test.describe('Scrambler — background tap pauses all clusters (#43)', () => {
 });
 
 /**
- * Critical post-v0.1.0 regression: after a user collapsed a card via
- * the – button, the cluster that owned that card stayed paused
- * indefinitely. Sibling clusters resumed normally, and bg-tap
- * unpause didn't unstick the affected cluster. Root cause:
- * .scrambler-cluster is inset: 0 so the cluster fills the entire
- * Scrambler; collapsing under-cursor never fires pointerleave, so
- * hoverPaused stays true forever after anyCardOpen flips false.
+ * Unified-pause contract (post-refactor): all clusters share the
+ * same pause state, sourced from the Scrambler parent. There is no
+ * supported configuration where one cluster is paused while another
+ * orbits. These tests guard the all-or-nothing invariant at the DOM
+ * class level.
+ */
+test.describe('Scrambler — every cluster shares the same pause state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('.scrambler-cluster', { timeout: 5000 });
+  });
+
+  test('hovering anywhere on the Scrambler paints .paused on every cluster', async ({
+    page,
+  }) => {
+    const clusters = page.locator('.scrambler-cluster');
+    const count = await clusters.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Baseline (no hover) — every cluster unpaused.
+    for (let i = 0; i < count; i++) {
+      await expect(clusters.nth(i)).not.toHaveClass(/paused/);
+    }
+
+    // Hover into the Scrambler container. Every cluster should pause
+    // together, not just the topmost-in-DOM-order one.
+    await page.locator('.scrambler').first().hover();
+    for (let i = 0; i < count; i++) {
+      await expect(clusters.nth(i)).toHaveClass(/paused/);
+    }
+
+    // Move pointer well off the Scrambler. Every cluster should
+    // resume together.
+    await page.mouse.move(0, 0);
+    for (let i = 0; i < count; i++) {
+      await expect(clusters.nth(i)).not.toHaveClass(/paused/);
+    }
+  });
+
+  test('drag end always restores the shared dragging flag', async ({ page }) => {
+    /* The new dragging pause reason lives on the Scrambler parent.
+     * ScramblerCard listens for both pointerup/pointercancel and
+     * lostpointercapture so a system-preempted drag still releases
+     * the flag. We can't trigger an actual capture loss in
+     * Playwright, but we CAN verify the post-drag baseline: after
+     * a normal drag-end every cluster is back to unpaused (the
+     * smoke verification that drag state isn't leaking). */
+    const clusters = page.locator('.scrambler-cluster');
+    const card = page.locator('.scrambler-card').first();
+    const box = await card.boundingBox();
+    if (!box) throw new Error('card not visible');
+
+    // Quick drag gesture — press, move a few px, release.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 30, box.y + box.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up();
+
+    // After up + hover-off, no cluster should remain paused.
+    await page.mouse.move(0, 0);
+    const count = await clusters.count();
+    for (let i = 0; i < count; i++) {
+      await expect(clusters.nth(i)).not.toHaveClass(/paused/);
+    }
+  });
+});
+
+/**
+ * Critical post-v0.1.0 regression (kept under the refactor): after
+ * a user collapses a card, no cluster stays paused beyond the
+ * 800ms recentlyCollapsed grace, even if the user's pointer is
+ * parked inside the Scrambler.
  */
 test.describe('Scrambler — cluster resumes after collapse with pointer parked', () => {
   test('cluster orbit resumes after card collapses, pointer still over cluster', async ({

--- a/src/components/Scrambler.svelte
+++ b/src/components/Scrambler.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ScramblerCard, ScramblerCluster } from '../lib/scrambler/types';
+  import { isOrbitPaused } from '../lib/scrambler/pause';
   import ScramblerClusterComponent from './ScramblerCluster.svelte';
 
   interface Props {
@@ -14,43 +15,116 @@
   let width = $state(800);
   let height = $state(600);
 
-  /* Single source of truth for "any card is open anywhere on the
-   * Scrambler". Hoisted from each cluster so when one cluster has an
-   * expanded card, ALL clusters pause — keeping the user's reading
-   * focus on the open card rather than letting sibling clusters orbit
-   * in the background. Also smooths a UX glitch where one cluster
-   * frozen + another moving read as "broken state". */
-  let anyCardOpen = $state(false);
-
-  /* Single source of truth for the sticky background-tap pause (#43).
-   * Hoisted so a click on ANY cluster's background freezes (or
-   * resumes) every cluster together. Previously each cluster carried
-   * its own tapPaused boolean and a click only flipped the one it
-   * landed in — half the orbit kept moving, which read as a bug.
-   * Tester also reported the inverse intent: "if clicking the
-   * background pauses anything it must pause everything, otherwise
-   * remove the behavior." A single shared boolean is the simplest
-   * possible coordination. */
+  /*
+   * SINGLE-SOURCE-OF-TRUTH PAUSE STATE.
+   *
+   * Every cluster reads the same `paused` derived. There is no
+   * intentional UX reason for one cluster to pause while another
+   * orbits — the prior per-cluster model produced asymmetric freezes
+   * (one cluster's local hover/focus/drag flag could stick without
+   * affecting siblings, and the user had no recovery path short of
+   * very specific pointer choreography). Hoisting every reason here
+   * removes that whole class of bugs at the root.
+   *
+   * Reasons:
+   *   hovered            — pointer is anywhere inside the Scrambler
+   *                        (mouse/pen only — touch never sets it)
+   *   focusInside        — keyboard focus is inside the Scrambler
+   *                        (gated by isKeyboardActive in the
+   *                        derivation so click-driven focus on a
+   *                        button doesn't pin the orbit)
+   *   tapPaused          — sticky toggle from a background click
+   *   openCards          — set of currently-lifted card IDs;
+   *                        anyCardOpen = openCards.size > 0
+   *   dragging           — a card is mid-drag anywhere
+   *   recentlyCollapsed  — 800ms grace after a card-close so the
+   *                        spring transitions settle visually before
+   *                        orbital motion resumes
+   */
+  let hovered = $state(false);
+  let focusInside = $state(false);
+  let isKeyboardActive = $state(false);
   let tapPaused = $state(false);
-  function toggleTapPause() {
-    tapPaused = !tapPaused;
-  }
+  let openCards = $state<Set<string>>(new Set());
+  let dragging = $state(false);
+  let recentlyCollapsed = $state(false);
+  let collapseTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const anyCardOpen = $derived(openCards.size > 0);
+
+  const paused = $derived(
+    isOrbitPaused({
+      hover: hovered,
+      focus: focusInside && isKeyboardActive,
+      tap: tapPaused,
+      anyCardOpen,
+      dragging,
+      recentlyCollapsed,
+    }),
+  );
+
+  /* Card-close grace: when anyCardOpen transitions true→false, hold
+   * every cluster's orbit for 800ms so any in-flight spring
+   * transitions on the closing card finish settling. Also force-clear
+   * hovered + focusInside on the same edge — the .scrambler div is
+   * the outermost pause boundary and closing a card under the cursor
+   * doesn't fire pointerleave on the scrambler itself, so without an
+   * explicit reset the hover-pause would pin every cluster
+   * indefinitely after a close gesture. The close is an explicit
+   * "I'm done reading" signal; pointerenter re-engages hover-pause on
+   * the next pointer-from-outside if the user wants it. */
+  let prevAnyCardOpen = false;
+  $effect(() => {
+    const open = anyCardOpen;
+    if (prevAnyCardOpen && !open) {
+      recentlyCollapsed = true;
+      if (collapseTimer !== undefined) clearTimeout(collapseTimer);
+      collapseTimer = setTimeout(() => {
+        recentlyCollapsed = false;
+        collapseTimer = undefined;
+      }, 800);
+      hovered = false;
+      focusInside = false;
+    } else if (!prevAnyCardOpen && open) {
+      if (collapseTimer !== undefined) {
+        clearTimeout(collapseTimer);
+        collapseTimer = undefined;
+      }
+      recentlyCollapsed = false;
+    }
+    prevAnyCardOpen = open;
+  });
 
   $effect(() => {
-    if (!containerEl || typeof MutationObserver === 'undefined') return;
-    const update = () => {
-      anyCardOpen = !!containerEl?.querySelector(
-        '.scrambler-card.focused, .scrambler-card.expanded',
-      );
+    return () => {
+      if (collapseTimer !== undefined) clearTimeout(collapseTimer);
     };
-    update();
-    const obs = new MutationObserver(update);
-    obs.observe(containerEl, {
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['class'],
-    });
-    return () => obs.disconnect();
+  });
+
+  /* Global keyboard / pointer mode tracking. Keyboard activity gates
+   * focusInside from contributing to pause (so a click-driven focus
+   * doesn't pin the orbit). One listener pair for the whole
+   * Scrambler — was duplicated per-cluster before. */
+  $effect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (
+        e.key === 'Tab' ||
+        e.key === 'Enter' ||
+        e.key === ' ' ||
+        e.key.startsWith('Arrow')
+      ) {
+        isKeyboardActive = true;
+      }
+    };
+    const onPointer = () => {
+      isKeyboardActive = false;
+    };
+    window.addEventListener('keydown', onKey, true);
+    window.addEventListener('pointerdown', onPointer, true);
+    return () => {
+      window.removeEventListener('keydown', onKey, true);
+      window.removeEventListener('pointerdown', onPointer, true);
+    };
   });
 
   $effect(() => {
@@ -94,6 +168,41 @@
       if (pending !== undefined) clearTimeout(pending);
     };
   });
+
+  // ── Callbacks for descendants ────────────────────────────────────
+
+  function toggleTapPause() {
+    /* Guards: bg-tap that closes a card shouldn't also flip pause
+     * (A1 from the v0.1.0 clarity review). And a release-after-drag
+     * synthesized click shouldn't flip pause either. */
+    if (anyCardOpen) return;
+    if (dragging) return;
+    tapPaused = !tapPaused;
+  }
+
+  function onCardLiftedChange(cardId: string, lifted: boolean) {
+    /* Idempotent Set updates — robust against duplicate or missed
+     * calls (a card unmounting while lifted, a re-render firing the
+     * same transition twice). add/remove of an existing/missing key
+     * is a no-op rather than a count drift. */
+    if (lifted) {
+      if (openCards.has(cardId)) return;
+      openCards = new Set([...openCards, cardId]);
+    } else {
+      if (!openCards.has(cardId)) return;
+      const next = new Set(openCards);
+      next.delete(cardId);
+      openCards = next;
+    }
+  }
+
+  function onCardDragChange(isDragging: boolean) {
+    /* Card-level pointer capture means at most one card drags at a
+     * time, so a single boolean is sufficient. ScramblerCard also
+     * listens for lostpointercapture so a system-preempted drag
+     * doesn't strand this flag at true. */
+    dragging = isDragging;
+  }
 </script>
 
 <div
@@ -102,6 +211,25 @@
   role="region"
   aria-label="Interactive content navigator — use Tab to focus on cards, Enter to select"
   aria-live="polite"
+  onpointerenter={(e) => {
+    if (e.pointerType === 'mouse' || e.pointerType === 'pen') hovered = true;
+  }}
+  onpointerleave={(e) => {
+    if (e.pointerType === 'mouse' || e.pointerType === 'pen') hovered = false;
+  }}
+  onpointercancel={() => {
+    hovered = false;
+  }}
+  onfocusin={() => {
+    if (isKeyboardActive) focusInside = true;
+  }}
+  onfocusout={(e) => {
+    /* Only clear when focus is actually leaving the Scrambler
+     * entirely. Tab between sibling cards keeps focus inside; we
+     * don't want each Tab to trip a false focusout-then-focusin. */
+    if (e.relatedTarget instanceof Node && containerEl?.contains(e.relatedTarget)) return;
+    focusInside = false;
+  }}
 >
   {#each clusters as cluster, i (cluster.id)}
     <!--
@@ -129,9 +257,10 @@
       containerHeight={height}
       timeOffset={i * (Math.PI * 2 / 3) * 0.4 + manualTimeOffset}
       onCardSelect={onCardSelect}
-      {anyCardOpen}
-      {tapPaused}
+      {paused}
       onToggleTapPause={toggleTapPause}
+      onCardLiftedChange={onCardLiftedChange}
+      onCardDragChange={onCardDragChange}
     />
   {/each}
 

--- a/src/components/ScramblerCard.svelte
+++ b/src/components/ScramblerCard.svelte
@@ -12,6 +12,12 @@
     onDragStart?: () => void;
     onDragMove?: (cardId: string, clientX: number, clientY: number) => void;
     onDragEnd?: () => void;
+    /** Fires whenever isFocused/isExpanded transition into or out of
+     *  the "lifted" state (orbital → focused / expanded → orbital).
+     *  Drives the parent Scrambler's openCards Set, which is the
+     *  single source of truth for the shared `anyCardOpen` pause
+     *  reason. */
+    onLiftedChange?: (lifted: boolean) => void;
     /** Force initial state. Used by the /review interface to show
      *  collapsed + expanded side-by-side. Has no effect once the user
      *  toggles state via the + button. */
@@ -23,7 +29,7 @@
     previewMode?: boolean;
   }
 
-  let { card, position, onSelect, onDragStart, onDragMove, onDragEnd, initialExpanded = false, previewMode = false }: Props = $props();
+  let { card, position, onSelect, onDragStart, onDragMove, onDragEnd, onLiftedChange, initialExpanded = false, previewMode = false }: Props = $props();
 
   let isHovered = $state(false);
   // Two interaction states:
@@ -37,6 +43,28 @@
   let isExpanded = $state(initialExpanded);
   const isLifted = $derived(isFocused || isExpanded);
   let cardEl: HTMLDivElement | undefined = $state();
+
+  /* Report lift-state transitions up to the Scrambler parent so it
+   * can keep the openCards Set current. Idempotent on the parent
+   * side, but we still gate on edge changes here to avoid spamming
+   * the callback on every reactive re-evaluation. */
+  let prevLifted = false;
+  $effect(() => {
+    const lifted = isLifted;
+    if (lifted !== prevLifted) {
+      onLiftedChange?.(lifted);
+      prevLifted = lifted;
+    }
+  });
+
+  /* If the card unmounts while it was lifted (route change, content
+   * swap), tell the parent so its openCards Set doesn't keep a stale
+   * id and leave anyCardOpen pinned true. */
+  $effect(() => {
+    return () => {
+      if (prevLifted) onLiftedChange?.(false);
+    };
+  });
 
   const isForeground = $derived(position.z < 0.3);
   // Tester feedback round 2 (post-#237445d): make EVERY card pointer-
@@ -407,6 +435,19 @@
     }
   }
 
+  function handleLostPointerCapture() {
+    /* Defensive drag-end. Pointer capture can be silently lost
+     * (system gesture, OS preemption, dev tools opening, mid-drag
+     * navigation) without firing pointerup or pointercancel. Without
+     * this handler, isDragging stayed true → onDragEnd never fired
+     * → the parent's `dragging` pause reason stuck on, freezing the
+     * orbit indefinitely. Mirror the cleanup half of handlePointerUp
+     * (no tap-state advancement — capture was lost, not released). */
+    if (!isDragging) return;
+    isDragging = false;
+    if (onDragEnd) onDragEnd();
+  }
+
   function handlePointerUp(e: PointerEvent) {
     if (!isDragging) return;
     isDragging = false;
@@ -504,6 +545,7 @@
   onpointermove={handlePointerMove}
   onpointerup={handlePointerUp}
   onpointercancel={handlePointerUp}
+  onlostpointercapture={handleLostPointerCapture}
   onkeydown={handleCardKeydown}
   style:cursor={isDragging ? 'grabbing' : isDraggable ? 'grab' : 'default'}
 >

--- a/src/components/ScramblerCluster.svelte
+++ b/src/components/ScramblerCluster.svelte
@@ -6,7 +6,6 @@
     warpPhaseToAngle,
     FOREGROUND_ANGLE,
   } from '../lib/scrambler/orbital-math';
-  import { isOrbitPaused } from '../lib/scrambler/pause';
   import ScramblerCardComponent from './ScramblerCard.svelte';
 
   interface Props {
@@ -15,16 +14,17 @@
     containerHeight: number;
     timeOffset?: number;
     onCardSelect?: (card: import('../lib/scrambler/types').ScramblerCard) => void;
-    /* Hoisted from Scrambler — true when ANY cluster has a focused
-     * or expanded card. All clusters pause together so background
-     * orbits don't compete with the user's reading focus. */
-    anyCardOpen?: boolean;
-    /* Hoisted from Scrambler — sticky pause toggled by a background
-     * click on ANY cluster (#43). All clusters share the same value
-     * so one click pauses (and the next resumes) every cluster
-     * together. */
-    tapPaused?: boolean;
-    onToggleTapPause?: () => void;
+    /* Single-source pause state from the Scrambler parent. Every
+     * cluster reads the same value, so pause / resume is always
+     * synchronous across the whole Scrambler. There is intentionally
+     * no local pause state on this component — the asymmetric-freeze
+     * bug class the v0.1.0 → v0.1.1 fixes chased was a direct
+     * consequence of per-cluster bookkeeping; lifting it to the
+     * parent eliminates it at the root. */
+    paused: boolean;
+    onToggleTapPause: () => void;
+    onCardLiftedChange: (cardId: string, lifted: boolean) => void;
+    onCardDragChange: (isDragging: boolean) => void;
   }
 
   let {
@@ -33,45 +33,13 @@
     containerHeight,
     timeOffset = 0,
     onCardSelect,
-    anyCardOpen = false,
-    tapPaused = false,
+    paused,
     onToggleTapPause,
+    onCardLiftedChange,
+    onCardDragChange,
   }: Props = $props();
 
-  /* Two distinct pause sources, kept separate so each can be cleared
-   * independently — this is what fixes the "orbit doesn't restart"
-   * bug on both mobile and desktop. Previously a single isPaused
-   * flag was pinned true by focusin (clicking the toggle button
-   * focuses it, focusout never fires because the button stays
-   * rendered after collapse). Splitting the source lets pointer
-   * activity override stale focus state without affecting hover.
-   *
-   *   hoverPaused — true while a mouse/pen is over the cluster.
-   *                 Cleared by pointerleave. Touch never sets it.
-   *   focusPaused — true ONLY when keyboard-driven focus enters a
-   *                 descendant. Cleared by focusout OR any
-   *                 pointerdown anywhere on the document. Touch /
-   *                 mouse focus never sets it. */
-  let hoverPaused = $state(false);
-  let focusPaused = $state(false);
-  // Tester feedback (#40, #41): both testers wanted to stop the orbit
-  // to read at their own pace. Tapping the cluster background (not a
-  // card) toggles a sticky pause — separate from hover/focus so the
-  // user can intentionally hold the orbit still on touch devices.
-  // Hoisted to the Scrambler parent (#43) so the toggle freezes
-  // every cluster together; this component receives it as a prop.
-  let isKeyboardActive = $state(false);
   let clusterEl: HTMLDivElement | undefined = $state();
-  let isDraggingCard = $state(false);
-  // True for ~800ms after the last expanded/focused card closes (#39).
-  // .scrambler-card has a spring CSS transition on `transform`, so when
-  // `isLifted` flips off the scale interpolates from 1.0 back to the
-  // card's orbital scale. The orbit's per-frame scale updates re-target
-  // the spring constantly during that window — visible as two cards
-  // jockeying for position. Holding the orbit while the spring settles
-  // gives the card a stable target to land on.
-  let recentlyCollapsed = $state(false);
-  let collapseTimer: ReturnType<typeof setTimeout> | undefined;
 
   // Per-card phase offsets — added to a card's natural orbit phase so
   // the user can DRAG cards along the orbit. The offset persists after
@@ -79,123 +47,15 @@
   // phase position when the orbit resumes.
   let phaseOffsets = $state<Map<string, number>>(new Map());
 
-  /* React to the global anyCardOpen signal: when it transitions
-   * true → false, hold this cluster's orbit for 800ms so any
-   * spring transitions inside this cluster's cards finish settling
-   * before motion resumes. When it goes false → true we cancel
-   * any pending grace (we're going back to a paused state anyway).
-   *
-   * prevAnyCardOpen is intentionally a plain variable, not $state —
-   * we don't want writes to it to retrigger the effect. */
-  let prevAnyCardOpen = false;
-  $effect(() => {
-    const open = anyCardOpen;
-    if (prevAnyCardOpen && !open) {
-      recentlyCollapsed = true;
-      if (collapseTimer !== undefined) clearTimeout(collapseTimer);
-      collapseTimer = setTimeout(() => {
-        recentlyCollapsed = false;
-        collapseTimer = undefined;
-      }, 800);
-      /* Critical: clear hoverPaused and focusPaused on collapse.
-       *
-       * .scrambler-cluster is `position: absolute; inset: 0`, so the
-       * cluster fills the entire Scrambler region. When an expanded
-       * card collapses while the user's pointer is on its `–` close
-       * button, the card shrinks back to its orbital size but the
-       * pointer remains inside the cluster's bounds — no pointerleave
-       * fires. hoverPaused stays true forever, locking that single
-       * cluster's orbit even after anyCardOpen flips false and the
-       * recentlyCollapsed grace expires. Sibling clusters resume
-       * normally because the pointer was never over them, so the
-       * symptom presents as "the cluster whose card I just closed
-       * is the only one stuck", and bg-tap unpause doesn't help
-       * because it toggles tapPaused, not hoverPaused.
-       *
-       * Clearing both flags here resets the local pause state to the
-       * just-collapsed baseline. If the user actually moves the
-       * pointer onto a cluster from outside afterward, pointerenter
-       * will re-engage hover-pause as usual; if they keep the pointer
-       * parked, the orbit resumes (which is the intended close-gesture
-       * UX). focusPaused is force-cleared as belt-and-braces alongside
-       * — the global pointerdown listener usually handles it, but a
-       * keyboard-driven close path (Esc) doesn't fire pointerdown. */
-      hoverPaused = false;
-      focusPaused = false;
-    } else if (!prevAnyCardOpen && open) {
-      if (collapseTimer !== undefined) {
-        clearTimeout(collapseTimer);
-        collapseTimer = undefined;
-      }
-      recentlyCollapsed = false;
-    }
-    prevAnyCardOpen = open;
-  });
-
-  /* Separate unmount cleanup — runs only when the cluster unmounts,
-   * not on every anyCardOpen change. */
-  $effect(() => {
-    return () => {
-      if (collapseTimer !== undefined) clearTimeout(collapseTimer);
-    };
-  });
-
-  // Pause the orbital animation if hovered/focused, if any card is
-  // expanded, OR if a card is being dragged. Once the user finishes
-  // (collapses the expanded card or releases the drag), the cluster
-  // resumes orbital rotation — but with any drag-induced phase
-  // offsets still applied, so cards stay where they were dragged.
-  // tapPaused is a hoisted, shared signal — see Scrambler.svelte (#43).
-  const orbitPaused = $derived(
-    isOrbitPaused({
-      hover: hoverPaused,
-      focus: focusPaused,
-      tap: tapPaused,
-      anyCardOpen,
-      dragging: isDraggingCard,
-      recentlyCollapsed,
-    }),
-  );
-
-  /* Track keyboard vs pointer mode globally so focusin can decide
-   * whether it was triggered by a Tab (pause is desired UX so cards
-   * don't move under keyboard nav) or by a click/tap on a button
-   * (which also focuses the button on most browsers — but the user
-   * doesn't expect a click to pin the orbit). */
-  $effect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (
-        e.key === 'Tab' ||
-        e.key === 'Enter' ||
-        e.key === ' ' ||
-        e.key.startsWith('Arrow')
-      ) {
-        isKeyboardActive = true;
-      }
-    };
-    const onPointer = () => {
-      isKeyboardActive = false;
-      /* Pointer activity always overrides any stale focus pause —
-       * defense against iOS/desktop browsers that don't reliably
-       * fire focusout when focus stays on a still-rendered button
-       * after a card collapses. */
-      focusPaused = false;
-    };
-    window.addEventListener('keydown', onKey, true);
-    window.addEventListener('pointerdown', onPointer, true);
-    return () => {
-      window.removeEventListener('keydown', onKey, true);
-      window.removeEventListener('pointerdown', onPointer, true);
-    };
-  });
+  const orbitPaused = $derived(paused);
 
   // ── DRAG handlers ──────────────────────────────────────────────
   function handleCardDragStart() {
-    isDraggingCard = true;
+    onCardDragChange(true);
   }
 
   function handleCardDragEnd() {
-    isDraggingCard = false;
+    onCardDragChange(false);
   }
 
   function handleCardDragMove(cardId: string, clientX: number, clientY: number) {
@@ -334,50 +194,14 @@
   class:paused={orbitPaused}
   role="group"
   aria-label="{cluster.label} — {cluster.cards.length} items"
-  onpointerenter={(e) => {
-    /* Hover pause is a separate signal from focus pause so each can
-     * be cleared independently. Touch is excluded — there's no
-     * lingering hover state on touch. */
-    if (e.pointerType === 'mouse' || e.pointerType === 'pen') hoverPaused = true;
-  }}
-  onpointerleave={(e) => {
-    if (e.pointerType === 'mouse' || e.pointerType === 'pen') hoverPaused = false;
-  }}
-  onpointercancel={() => {
-    /* Touch interrupted (gesture stolen by browser scroll, OS, etc.).
-     * Mirror the v0.1.0-preview #39 fix that cleared isHovered: clear
-     * hoverPaused too, so a stale value can't pin the orbit after the
-     * pointer never sends a clean leave. */
-    hoverPaused = false;
-  }}
-  onfocusin={() => {
-    /* Only pause for keyboard-driven focus. A click or tap also
-     * triggers focusin (on the focusable target, e.g. a button) but
-     * the user doesn't expect that to pin the orbit. */
-    if (isKeyboardActive) focusPaused = true;
-  }}
-  onfocusout={() => (focusPaused = false)}
   onclick={(e) => {
-    /* Tap on the cluster background (not on a card) toggles the
-     * SHARED, sticky pause for the entire Scrambler (#43). The
-     * tapPaused state lives on the Scrambler parent so one click
-     * here pauses every cluster together; the next click resumes
-     * every cluster together. e.target === e.currentTarget rules
-     * out bubbled clicks from a card / label; isDraggingCard
-     * filters out the release event at the end of a drag.
-     *
-     * Also bail when a card is open: ScramblerCard's outside-tap
-     * effect uses the same background click to collapse the card,
-     * and we don't want the close gesture to silently switch the
-     * orbit into sticky-pause as a side effect. The orbit is
-     * already paused via anyCardOpen while the card is open, and
-     * once it closes the user expects motion to resume — flipping
-     * tapPaused here would freeze everything in a way they didn't
-     * ask for. */
+    /* Tap on the cluster background (not on a card) requests the
+     * SHARED tap-pause toggle from the parent. Parent applies the
+     * cross-cutting guards (anyCardOpen, dragging) before flipping.
+     * e.target === e.currentTarget filters bubbled clicks from cards
+     * / labels. */
     if (e.target !== e.currentTarget) return;
-    if (isDraggingCard) return;
-    if (anyCardOpen) return;
-    onToggleTapPause?.();
+    onToggleTapPause();
   }}
 >
   <span class="cluster-label" style:opacity={cluster.orbit === 'inner' ? 0.7 : 0.3}>
@@ -421,6 +245,7 @@
         onDragStart={handleCardDragStart}
         onDragMove={handleCardDragMove}
         onDragEnd={handleCardDragEnd}
+        onLiftedChange={(lifted) => onCardLiftedChange(card.id, lifted)}
       />
     </div>
   {/each}

--- a/tests/scrambler/orbit-pause.test.ts
+++ b/tests/scrambler/orbit-pause.test.ts
@@ -40,3 +40,63 @@ describe('isOrbitPaused', () => {
     expect(isOrbitPaused(sharedTapOnly)).toBe(isOrbitPaused(hoverOnly));
   });
 });
+
+/* Models the openCards Set behavior on the Scrambler parent. The
+ * Set is the new single source of truth for anyCardOpen after the
+ * unified-pause refactor, replacing the MutationObserver. Add/delete
+ * must be idempotent — a duplicate call for the same card id from
+ * a flickery $effect or an unmount-while-lifted cleanup must not
+ * cause a count drift. */
+describe('openCards Set semantics (unified-pause refactor)', () => {
+  function applyLifted(set: Set<string>, id: string, lifted: boolean): Set<string> {
+    if (lifted) {
+      if (set.has(id)) return set;
+      return new Set([...set, id]);
+    }
+    if (!set.has(id)) return set;
+    const next = new Set(set);
+    next.delete(id);
+    return next;
+  }
+
+  it('lifting a card adds its id; anyCardOpen flips true', () => {
+    let s = new Set<string>();
+    s = applyLifted(s, 'card-a', true);
+    expect(s.has('card-a')).toBe(true);
+    expect(s.size > 0).toBe(true);
+  });
+
+  it('unlifting the only lifted card empties the set', () => {
+    let s = new Set<string>(['card-a']);
+    s = applyLifted(s, 'card-a', false);
+    expect(s.size).toBe(0);
+  });
+
+  it('duplicate lift of the same card is a no-op', () => {
+    let s = new Set<string>(['card-a']);
+    const before = s;
+    s = applyLifted(s, 'card-a', true);
+    // Idempotent: same reference, no new allocation, no count drift.
+    expect(s).toBe(before);
+    expect(s.size).toBe(1);
+  });
+
+  it('unlifting a card that was never lifted is a no-op', () => {
+    let s = new Set<string>(['card-a']);
+    const before = s;
+    s = applyLifted(s, 'card-b', false);
+    expect(s).toBe(before);
+    expect(s.size).toBe(1);
+  });
+
+  it('two cards lifted then both unlifted clears the set', () => {
+    let s = new Set<string>();
+    s = applyLifted(s, 'card-a', true);
+    s = applyLifted(s, 'card-b', true);
+    expect(s.size).toBe(2);
+    s = applyLifted(s, 'card-a', false);
+    expect(s.size).toBe(1);
+    s = applyLifted(s, 'card-b', false);
+    expect(s.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

In response to a maintainer call: clusters were still freezing intermittently after card interactions, and there is **no intentional UX reason for one cluster to ever pause while another orbits**. The prior per-cluster pause bookkeeping was complexity in service of an intent that never existed — and three duplicated copies of every pause reason kept producing freeze bugs at their seams (PR #57, the iOS sticky-hover bug, etc.).

This refactor collapses every pause reason to a **single source of truth on `Scrambler.svelte`**. Each cluster reads the same `paused` derived as a prop and uses it directly. `ScramblerCluster.svelte` no longer carries any local pause state.

## The new contract

| Reason | Lives on | Set by | Cleared by |
|---|---|---|---|
| `hovered` | Scrambler | `pointerenter` on `.scrambler` (mouse/pen) | `pointerleave`, `pointercancel`, OR a card-close |
| `focusInside` | Scrambler | `focusin` on `.scrambler` (when keyboard-active) | `focusout` (leaving `.scrambler` entirely), OR a card-close |
| `isKeyboardActive` | Scrambler | Tab/Enter/Space/Arrow keydown | any pointerdown |
| `tapPaused` | Scrambler (already shared) | bg-click from any cluster | next bg-click |
| `openCards: Set<string>` | Scrambler | `onLiftedChange(id, true)` from a card | `onLiftedChange(id, false)` or unmount cleanup |
| `dragging` | Scrambler | `onDragChange(true)` from a card | `onDragChange(false)` OR `lostpointercapture` (NEW) |
| `recentlyCollapsed` | Scrambler | `anyCardOpen` true→false transition | 800ms timer |

```ts
anyCardOpen = openCards.size > 0
paused = hovered
       || (focusInside && isKeyboardActive)
       || tapPaused
       || anyCardOpen
       || dragging
       || recentlyCollapsed
```

## Three structural wins beyond the freeze-class fix

1. **MutationObserver → explicit callback.** `ScramblerCard` fires `onLiftedChange(lifted)` on every `isFocused / isExpanded` transition (plus unmount cleanup). `Scrambler` maintains `openCards` as an idempotent Set keyed by card id. The class-string-sniffing MutationObserver pattern is gone. **Closes refactor issue #53.**

2. **`lostpointercapture` handler on ScramblerCard.** A drag silently preempted by a system gesture (iOS swipe-back, OS interrupt, dev tools opening) used to strand `isDragging=true` forever. New handler clears the flag on capture loss alongside `pointerup` / `pointercancel`.

3. **`isOrbitPaused` now has one call site** with matching field names — no rename-at-the-boundary friction. **Closes refactor issue #48 partially** (the call-site shape that motivated it goes away).

## Trade-off the maintainer signed off on

- Hovering anywhere on the Scrambler now paints `.paused` on **every** cluster (the gentle-pulse animation runs across all card-wrappers). Previously only the topmost-by-DOM cluster received the hover.
- A drag in cluster A now pauses every cluster, not just A. Sibling clusters don't distract from the active gesture.

Both match the stated intent: "no intentional reason why one cluster would ever pause at a time."

## Tests

- `e2e/scrambler-tap-pause.test.ts` gains an "every cluster shares pause state" describe block: hover-anywhere paints `.paused` on all; mouse-off clears it on all; drag-end leaves all unpaused (smoke for dragging-flag-leak protection).
- `tests/scrambler/orbit-pause.test.ts` gains an "openCards Set semantics" describe block: idempotent add/delete, no count drift on duplicate or missing-key calls.

**Unit suite: 106/106 passing locally** (was 101 — +5 net). Build green.

## Coordinated with v0.1.1

v0.1.0 is already published; the iOS fixes (PR #56) and the cluster-stuck-after-collapse fix (PR #57) were waiting in `main` for the next Release publication. After this merges I'll re-prep the v0.1.1 release notes to cover all three deltas: iOS tap fixes, post-collapse resume, and the unified-pause refactor. Probably worth bumping to `v0.2.0` given the substantive behavior change (all-cluster pause) and the API change on internal cluster props — happy to call it whichever the maintainer prefers.

## Test plan

- [x] CI: Workers Build green
- [x] Desktop smoke: open card → close → orbit resumes within ~1s; hover Scrambler → all three clusters pulse; mouse off → all resume; bg-tap pauses all then unpauses all
- [x] Mobile smoke: tap card to focus → tap to expand → tap `–` → orbit resumes; tap pad off → fill transparent immediately
- [ ] Stress smoke: drag a card while hovering another; close mid-drag; verify no cluster sticks

https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh)_