### PR TITLE
fix(scrambler): hover only pauses when over a card, not background

### DIFF
--- a/e2e/scrambler-tap-pause.test.ts
+++ b/e2e/scrambler-tap-pause.test.ts
@@ -136,26 +136,45 @@ test.describe('Scrambler — every cluster shares the same pause state', () => {
     await page.waitForSelector('.scrambler-cluster', { timeout: 5000 });
   });
 
-  test('hovering anywhere on the Scrambler paints .paused on every cluster', async ({
+  test('hovering empty background is NOT meaningful — no cluster pauses', async ({
     page,
   }) => {
+    /* The Scrambler fills most of the viewport. If hovering the
+     * empty background paused the orbit, the orbit would never run
+     * in practice. Only hovering a card is a meaningful "I'm reading
+     * something" gesture. */
     const clusters = page.locator('.scrambler-cluster');
     const count = await clusters.count();
     expect(count).toBeGreaterThanOrEqual(2);
 
-    // Baseline (no hover) — every cluster unpaused.
+    // Move the pointer to a corner of the Scrambler that's
+    // demonstrably not over any card. We measure the Scrambler
+    // bounding box and aim at the top edge between the wordmark and
+    // any orbital card.
+    const scrambler = page.locator('.scrambler').first();
+    const box = await scrambler.boundingBox();
+    if (!box) throw new Error('scrambler not visible');
+    // Aim near top-right corner — outside all orbital ellipses.
+    await page.mouse.move(box.x + box.width - 32, box.y + 32);
+
+    // No cluster should be paused — the pointer is over Scrambler
+    // background, not a card.
     for (let i = 0; i < count; i++) {
       await expect(clusters.nth(i)).not.toHaveClass(/paused/);
     }
+  });
 
-    // Hover into the Scrambler container. Every cluster should pause
-    // together, not just the topmost-in-DOM-order one.
-    await page.locator('.scrambler').first().hover();
+  test('hovering a card paints .paused on every cluster', async ({ page }) => {
+    const clusters = page.locator('.scrambler-cluster');
+    const count = await clusters.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    await page.locator('.scrambler-card').first().hover();
     for (let i = 0; i < count; i++) {
       await expect(clusters.nth(i)).toHaveClass(/paused/);
     }
 
-    // Move pointer well off the Scrambler. Every cluster should
+    // Move pointer off the Scrambler entirely. Every cluster should
     // resume together.
     await page.mouse.move(0, 0);
     for (let i = 0; i < count; i++) {

--- a/src/components/Scrambler.svelte
+++ b/src/components/Scrambler.svelte
@@ -211,8 +211,23 @@
   role="region"
   aria-label="Interactive content navigator — use Tab to focus on cards, Enter to select"
   aria-live="polite"
-  onpointerenter={(e) => {
-    if (e.pointerType === 'mouse' || e.pointerType === 'pen') hovered = true;
+  onpointermove={(e) => {
+    /* Hover only pauses when the pointer is OVER A CARD — never over
+     * empty Scrambler background or a cluster label. The Scrambler
+     * fills most of the viewport, so a "hover anywhere = pause" rule
+     * would make the orbit never run in practice. Card hover is the
+     * only meaningful "I'm reading something" gesture; bg hover
+     * means nothing (and bg-click still toggles the sticky tap-pause
+     * if the user wants to hold the orbit still).
+     *
+     * pointermove bubbles from any descendant, so a single listener
+     * on .scrambler catches every gesture. We re-derive hovered on
+     * each move from the current target (~5-level closest() walk;
+     * negligible). Stationary pointers don't fire pointermove, so
+     * once set the value persists until the next motion. */
+    if (e.pointerType !== 'mouse' && e.pointerType !== 'pen') return;
+    const target = e.target as Element | null;
+    hovered = !!(target?.closest?.('.scrambler-card'));
   }}
   onpointerleave={(e) => {
     if (e.pointerType === 'mouse' || e.pointerType === 'pen') hovered = false;


### PR DESCRIPTION
## Summary

Maintainer feedback immediately after merging the unified-pause refactor (#58): "Hovering on background is not meaningful. Clicking on background can pause or unpause but not hovering on bg. It will never orbit if hovering on background interrupts orbit."

Correct call — the Scrambler fills most of the viewport, so a "hover anywhere = pause" rule makes the orbit essentially never run in practice. Card hover is the only meaningful "I'm reading something" gesture.

## Fix

Switch the hover signal from "pointer inside `.scrambler`" to "pointer over a `.scrambler-card`":

- Replace `pointerenter` / `pointerleave` on `.scrambler` with a single `pointermove` listener that re-derives `hovered` from `e.target.closest('.scrambler-card')`. pointermove bubbles from every card so one listener catches everything; stationary pointers don't fire it, so once set the value persists until the next motion.
- Cluster labels are `pointer-events: none` so they don't capture pointer events — events fall through to whatever's behind them. Empty bg → closest returns null → hovered=false. Card → closest returns the card → hovered=true.
- Keep `pointerleave` on `.scrambler` as a safety to clear `hovered` when the pointer leaves the Scrambler region entirely; `pointercancel` ditto.
- bg-click (tapPaused toggle) is **unchanged** — the explicit pause-by-tap gesture is still available when the user wants to hold the orbit still without hovering anything.

## Tests

Updated `e2e/scrambler-tap-pause.test.ts`:
- Old test "hovering anywhere paints `.paused` on every cluster" is replaced with two focused tests:
  1. **Hovering an empty background corner → NO cluster pauses.** Moves the mouse to the top-right corner of the Scrambler (outside all orbital ellipses) and asserts no `.paused` class on any cluster. This is exactly the maintainer's contract: bg hover is meaningless.
  2. **Hovering a card → every cluster pauses.** Asserts the all-or-nothing pause invariant from the refactor is preserved when hover *is* meaningful.

**Unit suite: 106/106 passing locally.** Build green.

## Test plan

- [x] CI: Workers Build green
- [ ] Desktop smoke: cursor parked on empty Scrambler bg → orbit visibly running; move cursor onto any card → all three clusters pulse; off the card → all resume
- [ ] Bg-click on empty area: orbit pauses (sticky); bg-click again: orbit resumes

## Coordinated with release notes

I'll fold this into the v0.1.1 / v0.2.0 publishing handoff so the final notes reflect the correct hover contract.

https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7RRfYqkP5miPztcfzqTBh)_